### PR TITLE
Bind number values using sqlite3 number bindings

### DIFF
--- a/test-www/index.html
+++ b/test-www/index.html
@@ -308,6 +308,29 @@
         });
       });
 
+      test("number values inserted using number bindings", function() {
+        stop();
+        var db = window.sqlitePlugin.openDatabase("Database", "1.0", "Demo", -1);
+        db.transaction(function(tx) {
+          tx.executeSql('DROP TABLE IF EXISTS test_table');
+          tx.executeSql('CREATE TABLE IF NOT EXISTS test_table (id integer primary key, data_text, data_int, data_real)');
+        }, function(err){ ok(false, err.message) }, function() {
+          db.transaction(function(tx) {
+            // create columns with no type affinity
+            tx.executeSql("insert into test_table (data_text, data_int, data_real) VALUES (?,?,?)", ["3.14", 314, 3.14], function(tx, res) {
+              equal(res.rowsAffected, 1, "row inserted");
+              tx.executeSql("select * from test_table", [], function(tx, res) {
+                start();
+                var row = res.rows.item(0);
+                strictEqual(row.data_text, "3.14", "data_text should have inserted data as text");
+                strictEqual(row.data_int, 314, "data_int should have inserted data as an integer");
+                strictEqual(row.data_real, 3.14, "data_real should have inserted data as a real");
+              });
+            });
+          });
+        });
+      });
+
   }
 
     </script>


### PR DESCRIPTION
This updates the plugin so that it binds number values using the
appropritate sqlite3 number binding functions (e.g. sqlite3_bind_int,
sqlite3_bind_double, etc.).

This fixes the issue where columns without a type affinity would store
number values as strings. The plugin now mirrors the behavior of the
HTML5 Web SQL API and stores the data as is.

Includes unit tests.
