### PR TITLE
Invoke parent transaction with error

### DIFF
--- a/test-www/index.html
+++ b/test-www/index.html
@@ -221,7 +221,7 @@
             });
           }, function(err) {
             start();
-            equal(err.message, 'a statement error callback did not return false');
+            ok(/bogustable/.test(err.message), "should report bad statement");
             stop();
             db.transaction(function(tx) {
               tx.executeSql("select count(*) as cnt from test_table", [], function(tx, res) {
@@ -277,7 +277,7 @@
               });
             });
           }, function(err) {
-            ok(/a statement with no error handler failed/.test(err.message), "check error message");
+            ok(/bogustable/.test(err.message), "should report bad statement");
             db.transaction(function(tx) {
               tx.executeSql("select count(*) as cnt from test_table", [], function(tx, res) {
                 start();
@@ -359,36 +359,50 @@
       });
 
       test("syntax error", function() {
-        stop();
+        stop(2);
         db.transaction(function(tx) {
           // This insertion has a sql syntax error
-          tx.executeSql("insert into test_table (data) VALUES ", [123], function(tx, error) {
-            ok(false, error.message);
+          tx.executeSql("insert into test_table (data) VALUES ", [123], function(tx) {
+            ok(false, "unexpected success");
             start();
           }, function(tx, error) {
             strictEqual(error.code, SQLException.SYNTAX_ERR, "error.code === SYNTAX_ERR");
             equal(error.message, "Request failed: insert into test_table (data) VALUES ,123", "error.message");
             start();
+
+            // We want this error to fail the entire transaction
+            return true;
           });
+        }, function (error) {
+          strictEqual(error.code, SQLException.SYNTAX_ERR, "error.code === SYNTAX_ERR");
+          equal(error.message, "Request failed: insert into test_table (data) VALUES ,123", "error.message");
+          start();
         });
       });
 
       test("constraint violation", function() {
-        stop();
+        stop(2);
         db.transaction(function(tx) {
           tx.executeSql("insert into test_table (data) VALUES (?)", [123], null, function(tx, error) {
             ok(false, error.message);
           });
 
           // This insertion will violate the unique constraint
-          tx.executeSql("insert into test_table (data) VALUES (?)", [123], function(tx, error) {
-            ok(false, error.message);
+          tx.executeSql("insert into test_table (data) VALUES (?)", [123], function(tx) {
+            ok(false, "unexpected success");
             start();
           }, function(tx, error) {
             strictEqual(error.code, SQLException.CONSTRAINT_ERR, "error.code === CONSTRAINT_ERR");
             equal(error.message, "Request failed: insert into test_table (data) VALUES (?),123", "error.message");
             start();
+
+            // We want this error to fail the entire transaction
+            return true;
           });
+        }, function(error) {
+          strictEqual(error.code, SQLException.CONSTRAINT_ERR, "error.code === CONSTRAINT_ERR");
+          equal(error.message, "Request failed: insert into test_table (data) VALUES (?),123", "error.message");
+          start();
         });
       });
 

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -172,12 +172,9 @@ if (!window.Cordova) window.Cordova = window.cordova;
     handler(this, payload);
   };
 
-  SQLitePluginTransaction.prototype.handleStatementFailure = function(handler, response) {
-    if (!handler){
-      throw new Error("a statement with no error handler failed: " + response.message)
-    }
-    if (handler(this, response)){
-      throw new Error("a statement error callback did not return false");
+  SQLitePluginTransaction.prototype.handleStatementFailure = function(handler, error) {
+    if (!handler || handler(this, error)){
+      throw error;
     }
   };
 


### PR DESCRIPTION
This fix updates the plugin so that the transaction error callback is
invoked with the error from the statement that caused the transaction
to fail and rollback.

Previously only the executeSql error callback would be invoked with the
error.

This mirrors the behavior of the HTML5 Web SQL
API.

Includes unit tests. Also includes some formatting fixes to the unit tests to make the code base more consistent.
