### PR TITLE
Create database directory if needed to ensure Android 4.4 compatibility

### DIFF
--- a/src/android/org/pgsqlite/SQLitePlugin.java
+++ b/src/android/org/pgsqlite/SQLitePlugin.java
@@ -198,6 +198,10 @@ public class SQLitePlugin extends CordovaPlugin
 
 		File dbfile = this.cordova.getActivity().getDatabasePath(dbname + ".db");
 
+		if (!dbfile.exists()) {
+		    dbfile.getParentFile().mkdirs();
+		}
+
 		Log.v("info", "Open sqlite db: " + dbfile.getAbsolutePath());
 
 		SQLiteDatabase mydb = SQLiteDatabase.openOrCreateDatabase(dbfile, null);


### PR DESCRIPTION
I just got my Nexus 5 with Android 4.4 KitKat and installed a Cordova application which uses the SQLitePlugin.

On application start, LogCat throws an SQLite Error:

```
11-04 12:10:31.767  15471-15508/? E/SQLiteLog﹕ (14) cannot open file at line 30191 of [00bb9c9ce4]
11-04 12:10:31.767  15471-15508/? E/SQLiteLog﹕ (14) os_unix.c:30191: (2) open(/data/data/com.mypackage.myapp/databases/Database-DB.db) -
11-04 12:10:31.777  15471-15508/? E/SQLiteDatabase﹕ Failed to open database '/data/data/com.mypackage.myapp/databases/Database-DB.db'.
    android.database.sqlite.SQLiteCantOpenDatabaseException: unknown error (code 14): Could not open database
```

Testing several things, I've figured out that Android (4.4) does not create the _databases_ directory automatically. My additions ensure that the directory exists before we try to open/create the database.
