### PR TITLE
Amazon-FireOS support added

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@
         </config-file>
 
         <!-- Cordova >= 3.0.0 -->
-        <config-file target="config.xml" parent="/*">
+        <config-file target="res/xml/config.xml" parent="/*">
             <feature name="SQLitePlugin">
                 <param name="android-package" value="org.pgsqlite.SQLitePlugin"/>
             </feature>


### PR DESCRIPTION
Because the FireOS core is Android the SQLitePlugin can also be used for Amazon FireOS. I only added the needed entries to the `plugin.xml` file and reused the android code.
