### PR TITLE
Fix path to config.xml for Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@
         </config-file>
 
         <!-- Cordova >= 3.0.0 -->
-        <config-file target="config.xml" parent="/*">
+        <config-file target="res/xml/config.xml" parent="/*">
             <feature name="SQLitePlugin">
                 <param name="android-package" value="org.pgsqlite.SQLitePlugin"/>
             </feature>


### PR DESCRIPTION
The plugin was failing to work on Android, and I tracked it down to an incorrect reference to the config.xml file for Android.

Here's the quick fix.
