### PR TITLE
Fix database extension on iOS

### DIFF
--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -180,7 +180,7 @@ static void sqlite_regexp(sqlite3_context* context, int argc, sqlite3_value** va
     if (dbFile == NULL) {
         return NULL;
     }
-    NSString *dbPath = [NSString stringWithFormat:@"%@/%@", appDocsPath, dbFile];
+    NSString *dbPath = [NSString stringWithFormat:@"%@/%@.db", appDocsPath, dbFile];
     return dbPath;
 }
 


### PR DESCRIPTION
In Android the database is created with .db extension but in iOS the
database is being created without the extension, this can cause problems
with cross platform javascript.

Be aware that the pull request of facine https://github.com/brodysoft/Cordova-SQLitePlugin/pull/62 would have to be updated or the bug will be reintroduced.
