### PR TITLE
Removed empty intent-filter

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,8 +36,6 @@
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <activity android:name="org.pgsqlite.SQLitePlugin"
                       android:label="@string/app_name">
-                <intent-filter>
-                </intent-filter>
             </activity>
         </config-file>
 


### PR DESCRIPTION
[In the documentation of Android App Manifest](http://developer.android.com/guide/topics/manifest/intent-filter-element.html) it's stated that the &lt;intent-filter&gt; element must not be empty, as it must at least have an &lt;action&gt; element.

The empty intent-filter caused AppGyver Steroids builds to fail in compilation of AndroidManifest.xml with the error `Missing one of the key attributes 'action#name,category#name' on element intent-filter`. Removing the intent-filter from the plugin.xml of this plugin fixed the issue.

An empty &lt;intent-filter&gt; does not do anything, but can cause AndroidManifest.xml to not compile.
