### PR TITLE
Retrieving large integer/float gives wrong values

### DIFF
--- a/src/android/org/pgsqlite/SQLitePlugin.java
+++ b/src/android/org/pgsqlite/SQLitePlugin.java
@@ -571,10 +571,10 @@ public class SQLitePlugin extends CordovaPlugin
 									row.put(key, JSONObject.NULL);
 									break;
 								case Cursor.FIELD_TYPE_INTEGER:
-									row.put(key, cur.getInt(i));
+									row.put(key, cur.getLong(i));
 									break;
 								case Cursor.FIELD_TYPE_FLOAT:
-									row.put(key, cur.getFloat(i));
+									row.put(key, cur.getDouble(i));
 									break;
 								case Cursor.FIELD_TYPE_BLOB:
 									row.put(key, new String(Base64.encode(cur.getBlob(i), Base64.DEFAULT)));


### PR DESCRIPTION
Problem: sqlite stores integer or float as 64-bit values, but the java code (SQLitePlugin.java) retrieves them as 32-bit, so the retrieved values would be truncated.
Solution: replace cur.getInt(..) to cur.getLong(..), and cur.getFloat(..) to cur.getDouble(..).
