### PR TITLE
test.sh should not emit coffeescript header

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -32,7 +32,7 @@ if [[ $? != 0 ]]; then # run from the bin/ directory
 fi
 
 # compile coffeescript
-coffee -cl -o ../www ../SQLitePlugin.coffee.md
+coffee --no-header -cl -o ../www ../SQLitePlugin.coffee.md
 
 if [[ $? != 0 ]]; then
   echo "coffeescript compilation failed"


### PR DESCRIPTION
Since you seem to prefer coffeescript without
the header (e.g. "Generated by CoffeeScript v. etc."),
this fix ensures that the test script does the same
thing. Keeps my working branch from getting dirty!
