### PR TITLE
Implement rowsAffected for Android < 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ The automatic "`.db`" database file extension is now removed for the Android ver
 - The db version, display name, and size parameter values are not supported and will be ignored.
 - The sqlite plugin will not work before the callback for the "deviceready" event has been fired, as described in **Usage**.
 - For Android version, there is an issue with background processing that affects transaction error handling and may affect nested transactions.
-- For Android below SDK 11:
- - `rowsAffected` is not returned for INSERT or DELETE statements
 - Background processing model could be improved with one background thread per database connection.
 - For iOS, iCloud backup is NOT optional and should be.
 - Missing db creation callback

--- a/test-www/www/index.html
+++ b/test-www/www/index.html
@@ -123,6 +123,79 @@
 
         });
 
+        test(suiteName + 'test rowsAffected', function () {
+          var db = openDatabase("RowsAffected", "1.0", "Demo", DEFAULT_SIZE);
+
+          stop();
+
+          function test1(tx) {
+            tx.executeSql('DROP TABLE IF EXISTS characters');
+            tx.executeSql('CREATE TABLE IF NOT EXISTS characters (name, creator, fav tinyint(1))');
+            tx.executeSql('UPDATE characters SET name = ?', ['foo'], function (tx, res) {
+              equal(res.rowsAffected, 0, 'nothing updated');
+              tx.executeSql('DELETE from characters WHERE name = ?', ['foo'], function (tx, res) {
+                equal(res.rowsAffected, 0, 'nothing deleted');
+                tx.executeSql('UPDATE characters SET name = ?', ['foo'], function (tx, res) {
+                  equal(res.rowsAffected, 0, 'nothing updated');
+                  tx.executeSql('DELETE from characters', [], function (tx, res) {
+                    equal(res.rowsAffected, 0, 'nothing deleted');
+                    test2(tx);
+                  });
+                });
+              });
+            });
+          }
+
+          function test2(tx) {
+            tx.executeSql('INSERT INTO characters VALUES (?,?,?)', ['Sonic', 'Sega', 0], function (tx, res) {
+              equal(res.rowsAffected, 1);
+              tx.executeSql('INSERT INTO characters VALUES (?,?,?)', ['Mario', 'Nintendo', 0], function (tx, res) {
+                equal(res.rowsAffected, 1);
+                tx.executeSql('INSERT INTO characters VALUES (?,?,?)', ['Samus', 'Nintendo', 0], function (tx, res) {
+                  equal(res.rowsAffected, 1);
+                  tx.executeSql('UPDATE characters SET fav=1 WHERE creator=?', ['Nintendo'], function (tx, res) {
+                    equal(res.rowsAffected, 2);
+                    tx.executeSql('UPDATE characters SET fav=1 WHERE creator=?', ['Konami'], function (tx, res) {
+                      equal(res.rowsAffected, 0);
+                      tx.executeSql('UPDATE characters SET fav=1', [], function (tx, res) {
+                        equal(res.rowsAffected, 3);
+                        test3(tx);
+                      });
+                    });
+                  });
+                });
+              });
+            });
+          }
+
+          function test3(tx) {
+            tx.executeSql('INSERT INTO characters VALUES (?,?,?)', ['Mega Man', 'Capcom', 0], function (tx, res) {
+              equal(res.rowsAffected, 1);
+              tx.executeSql('UPDATE characters SET fav=?, name=? WHERE creator=?;', [1, 'X', 'Capcom'], function (tx, res) {
+                equal(res.rowsAffected, 1);
+                tx.executeSql('UPDATE characters SET fav=? WHERE (creator=? OR creator=?)', [1, 'Capcom', 'Nintendo'], function (tx, res) {
+                  equal(res.rowsAffected, 3);
+                  tx.executeSql('DELETE FROM characters WHERE name="Samus";', [], function (tx, res) {
+                    equal(res.rowsAffected, 1);
+                    tx.executeSql('UPDATE characters SET fav=0,name=?', ["foo"], function (tx, res) {
+                      equal(res.rowsAffected, 3);
+                      tx.executeSql('DELETE FROM characters', [], function (tx, res) {
+                        start();
+                        equal(res.rowsAffected, 3);
+                      });
+                    });
+                  });
+                });
+              });
+            });
+          }
+
+          db.transaction(function (tx) {
+            test1(tx);
+          })
+        });
+
+
         test(suiteName + "nested transaction test", function() {
 
           var db = openDatabase("Database2", "1.0", "Demo", DEFAULT_SIZE);


### PR DESCRIPTION
Implements rowsAffected using a pretty basic
regex + extra SELECT query strategy. It's not
perfect, but it passes a pretty impressive suite
of unit tests, and the query it executes is
wrapped in a try/catch, so it's better than nothing.

With this commit, the test suite now passes 100% on Android 2.3, Android 4.4, and iOS 7.

And yeah, this is on top of my three other PRs, to avoid bitrotting myself. :)
