### PR TITLE
Fix subquery syntax error on Android 2.3

### DIFF
--- a/test-www/www/index.html
+++ b/test-www/www/index.html
@@ -195,6 +195,43 @@
           })
         });
 
+        test(suiteName + 'test rowsAffected advanced', function () {
+          var db = openDatabase("RowsAffectedAdvanced", "1.0", "Demo", DEFAULT_SIZE);
+
+          stop();
+
+          db.transaction(function (tx) {
+            tx.executeSql('DROP TABLE IF EXISTS characters');
+            tx.executeSql('CREATE TABLE IF NOT EXISTS characters (name, creator, fav tinyint(1))');
+            tx.executeSql('DROP TABLE IF EXISTS companies');
+            tx.executeSql('CREATE TABLE IF NOT EXISTS companies (name, fav tinyint(1))');
+            tx.executeSql('INSERT INTO characters VALUES (?,?,?)', ['Sonic', 'Sega', 0], function (tx, res) {
+              equal(res.rowsAffected, 1);
+              tx.executeSql('INSERT INTO characters VALUES (?,?,?)', ['Tails', 'Sega', 0], function (tx, res) {
+                tx.executeSql('INSERT INTO companies VALUES (?,?)', ['Sega', 1], function (tx, res) {
+                  equal(res.rowsAffected, 1);
+                  // query with subquery
+                  var sql = 'UPDATE characters ' +
+                      ' SET fav=(SELECT fav FROM companies WHERE name=?)' +
+                      ' WHERE creator=?';
+                  tx.executeSql(sql, ['Sega', 'Sega'], function (tx, res) {
+                    equal(res.rowsAffected, 2);
+                    // query with 2 subqueries
+                    var sql = 'UPDATE characters ' +
+                        ' SET fav=(SELECT fav FROM companies WHERE name=?),' +
+                        ' creator=(SELECT name FROM companies WHERE name=?)' +
+                        ' WHERE creator=?';
+                    tx.executeSql(sql, ['Sega', 'Sega', 'Sega'], function (tx, res) {
+                      start();
+                      equal(res.rowsAffected, 2);
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+
 
         test(suiteName + "nested transaction test", function() {
 


### PR DESCRIPTION
Prompted by [this bug report](https://github.com/pouchdb/pouchdb/issues/2434#issuecomment-48587941).

For the `rowsAffected` compatibility logic, I forgot to account for the case of subqueries. Also, I forgot to wrap the `prepareStatement` in a try/catch, meaning if the SELECT query throws, then the whole thing fails.  This fixes both problems and adds some unit tests to verify.

Tested on Android 4.4, Android 2.3, and iOS 7, no regressions.
