### PR TITLE
Fix plugin.xml validation

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     id="com.phonegap.plugins.sqlite"
     version="0.7.0">
 
     <name>SQLitePlugin</name>
+
+    <license>MIT</license>
+
+    <description>Native interface to SQLite for PhoneGap/Cordova. Allows you to use more storage and provides more flexibility than the standard Web SQL database (window.openDatabase).</description>
+    <author>Chris Brody</author>
 
     <engines>
         <engine name="cordova" version=">=3.0.0" />


### PR DESCRIPTION
The [PhoneGap Build plugins list](https://build.phonegap.com/plugins) won't accept a plugin without a valid `plugin.xml`. After the change, this XML file passes [W3C validation](http://validator.w3.org/check).

After this fix, could you also please upload it to the PhoneGap Build plugins list?  A search for "sqlite" turns up two different forks, but not this repo:
- https://github.com/millerjames01/Cordova-SQLitePlugin
- https://github.com/huserben/Cordova-WP-SqlitePlugin
