### PR TITLE
added support to enabling database when ios is locked

### DIFF
--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -132,7 +132,7 @@ static void sqlite_regexp(sqlite3_context* context, int argc, sqlite3_value** va
 
     NSString *dbname = [self getDBPath:dbfilename at:dblocation];
 
-    BOOL enableDatabaseWhenLocked = [options valueForKey:@"enableDatabaseWhenLocked"] == nil ? NO : [[options valueForKey:@"enableDatabaseWhenLocked"] boolValue];
+    NSNumber *enableDatabaseWhenLocked = [options valueForKey:@"enableDatabaseWhenLocked"];
 
     if (dbname == NULL) {
         NSLog(@"No db name specified for open");

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -110,7 +110,7 @@ static void sqlite_regexp(sqlite3_context* context, int argc, sqlite3_value** va
 }
 
 -(void)enableDatabaseWhenLocked:(BOOL)enable path:(NSString*)path{
-    NSDictionary *attributes = @{NSFileProtectionKey: enable ? NSFileProtectionCompleteUnlessOpen : NSFileProtectionComplete};
+    NSDictionary *attributes = @{NSFileProtectionKey: enable ? NSFileProtectionNone : NSFileProtectionComplete};
     NSError *error;
     if(![[NSFileManager defaultManager] setAttributes:attributes
                                          ofItemAtPath:path

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -198,6 +198,7 @@
         };
       })(this);
       this.openDBs[this.dbname] = DB_STATE_INIT;
+      this.openargs.enableDatabaseWhenLocked = root.sqlitePlugin.enableDatabaseWhenLocked;
       cordova.exec(opensuccesscb, openerrorcb, "SQLitePlugin", "open", [this.openargs]);
     }
   };
@@ -567,6 +568,7 @@
     sqliteFeatures: {
       isSQLitePlugin: true
     },
+    enableDatabaseWhenLocked: null,
     openDatabase: SQLiteFactory.opendb,
     deleteDatabase: SQLiteFactory.deleteDb
   };


### PR DESCRIPTION
if root.sqlitePlugin.enableDatabaseWhenLocked is not setted, plugin is using the default security.
if setted to true ios would permit an open before lock database to be used.
if setted to false ios would forbid any use of the file when it is locked.
