### PR TITLE
rename lawnchair adaptor

### DIFF
--- a/Lawnchair-adapter/Lawnchair-sqlitePlugin.js
+++ b/Lawnchair-adapter/Lawnchair-sqlitePlugin.js
@@ -1,4 +1,4 @@
-Lawnchair.adapter('webkit-sqlite', (function () {
+Lawnchair.adapter('cordova-sqlite', (function () {
     // private methods 
     var fail = function (e, i) { console.log('error in sqlite adaptor!', e, i) }
     ,   now  = function () { return new Date() } // FIXME need to use better date fn


### PR DESCRIPTION
Rename it so it doesn't clash with the standard webkit-sqlite adaptor, so that both can be loaded.
