### PR TITLE
Removed the usage of an undefined function.

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -47,8 +47,6 @@ exports.defineAutoTests = function() {
 
           expect(db).toBeDefined()
 
-          stop();
-
           db.transaction(function(tx) {
 
             expect(tx).toBeDefined()


### PR DESCRIPTION
The automated tests defined in file tests/tests.js did not pass and the error (at least in my environment) was the usage of an undefined stop-function. After removing this line, the tests passed.
