### PR TITLE
Changed id to "cordova-sqlite-storage" in plugin.xml.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="io.litehelpers.cordova.sqlite"
+    id="cordova-sqlite-storage"
     version="0.7.11-dev">
 
     <name>Cordova sqlite storage plugin</name>


### PR DESCRIPTION
Because the plugin name in config.xml (i.e. `<plugin name="cordova-sqlite-storage" spec="~0.7.10" />`) doesn't match the plugin id in `plugin.xml`, the plugin is rediscovered, redownloaded from npm and rebuilt on every cordova build.
