### PR TITLE
Changed remove method to work with key array

### DIFF
--- a/Lawnchair-adapter/Lawnchair-sqlitePlugin.js
+++ b/Lawnchair-adapter/Lawnchair-sqlitePlugin.js
@@ -172,18 +172,21 @@ Lawnchair.adapter('cordova-sqlite', (function () {
 			return this
 		},
 
-		remove: function (keyOrObj, cb) {
-			var that = this
-			,   key  = typeof keyOrObj === 'string' ? keyOrObj : keyOrObj.key
-			,   del  = "DELETE FROM " + this.name + " WHERE id = ?"
-			,   win  = function () { if (cb) that.lambda(cb).call(that) }
-
-			this.db.transaction( function (t) {
-				t.executeSql(del, [key], win, fail);
-			});
-
-			return this;
-		},
+	       	remove: function (keyOrObj, cb) {
+	            	var that = this
+				, key = typeof keyOrObj === 'string' ? keyOrObj : (Array.isArray(keyOrObj) ? null : keyOrObj.key)
+				, del = "DELETE FROM " + this.name + (Array.isArray(keyOrObj) ? " WHERE id IN ('" + keyOrObj.join("','") + "')" : " WHERE id = ?")
+				, win = function () { if (cb) that.lambda(cb).call(that) }
+	
+	            	this.db.transaction(function (t) {
+	                	if (key == null)
+	                    	t.executeSql(del, [], win, fail);
+	                	else
+	                    	t.executeSql(del, [key], win, fail);
+	            	});
+	
+	            	return this;
+	        },
 
 		nuke: function (cb) {
 			var nuke = "DELETE FROM " + this.name


### PR DESCRIPTION
I made a quick mod to remove method. Following lawnchair api docs (http://brian.io/lawnchair/api/) remove method have to accept also key array.

With method modified these works 

```
Lawnchair({name:'people'}, function() {

    this.remove('mark', function() {
                    // ...
        });
    this.remove({key:'mark'}, function() {
                    // ...
        });

    this.remove(['mark','stefano'], function() {        }); // Now this works

})
```
