### PR TITLE
Fix sql exception error: Unsupported argument type: undefined on Windows

### DIFF
--- a/src/windows/SQLite3-Win-RT/SQLite3JS/js/SQLite3.js
+++ b/src/windows/SQLite3-Win-RT/SQLite3JS/js/SQLite3.js
@@ -46,6 +46,7 @@
             resultCode = this.statement.bindText(index, arg);
             break;
           case 'null':
+          case 'undefined':
             resultCode = this.statement.bindNull(index);
             break;
           default:


### PR DESCRIPTION
Fixes receiving the 'error Fix sql exception error: Unsupported argument type: undefined' when using this plugin on windows 10 devices.