### PR TITLE
Change windows target platform version

### DIFF
--- a/src/windows/SQLite3-Win-RT/SQLite3/SQLite3.UWP/SQLite3.UWP.vcxproj
+++ b/src/windows/SQLite3-Win-RT/SQLite3/SQLite3.UWP/SQLite3.UWP.vcxproj
@@ -35,7 +35,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>


### PR DESCRIPTION
VS 2017 support for UWP development (that carries v141 build toolset) by default installs Windows10 SDK v10.0.14393. This plugin still uses v10.0.10586 so to avoid asking users to install additional SDKs we need to upgrade it to 14393

See docs: https://www.visualstudio.com/en-us/productinfo/vs2017-install-product-Community.workloads#universal-windows-platform-development