### PR TITLE
Fix ProGuard issue with map.keySet() on Java 8

### DIFF
--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -13,6 +13,8 @@ import android.util.Log;
 import java.io.File;
 import java.lang.IllegalArgumentException;
 import java.lang.Number;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -153,19 +155,21 @@ public class SQLitePlugin extends CordovaPlugin {
      */
     @Override
     public void onDestroy() {
-        while (!dbrmap.isEmpty()) {
-            String dbname = dbrmap.keySet().iterator().next();
+        Iterator<Map.Entry<String, DBRunner>> iterator = dbrmap.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, DBRunner> entry = iterator.next();
+
+            String dbname = entry.getKey();
+            DBRunner r = entry.getValue();
 
             this.closeDatabaseNow(dbname);
-
-            DBRunner r = dbrmap.get(dbname);
             try {
                 // stop the db runner thread:
                 r.q.put(new DBQuery());
             } catch(Exception e) {
                 Log.e(SQLitePlugin.class.getSimpleName(), "couldn't stop db thread", e);
             }
-            dbrmap.remove(dbname);
+            iterator.remove();
         }
     }
 


### PR DESCRIPTION
This fixes a ProGuard warning that occurs on Java 8, due to the
change of return type of `Map.keySet()`. This warning causes the build to
fail. See output attached below.

This issue is fixed by using `Map.entrySet()` rather than `.keySet()`. Use of
`entrySet()` is also preferable when both key and value are required, as
is the case here.

In addition, `Iterator.remove()` is used rather than `Map.remove()`, which
is the correct way of removing an entry while iterating. See
https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#keySet--

> If the map is modified while an iteration over the set is in progress
> (except through the iterator's own remove operation), the results of
> the iteration are undefined.

---
```
Warning: io.sqlc.SQLitePlugin: can't find referenced method 'java.util.concurrent.ConcurrentHashMap$KeySetView keySet()' in library class java.util.concurrent.ConcurrentHashMap
Warning: there were 1 unresolved references to library class members.
         You probably need to update the library versions.
         (http://proguard.sourceforge.net/manual/troubleshooting.html#unresolvedlibraryclassmember)
Warning: Exception while processing task java.io.IOException: Please correct the above warnings first.
```