### PR TITLE
Master

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/litehelpers/Cordova-sqlite-storage.git"
+    "url": "git+https://github.com/litehelpers/Cordova-sqlite-storage.git"
   },
   "keywords": [
     "sqlite",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/litehelpers/Cordova-sqlite-storage.git"
+    "url": "git+https://github.com/litehelpers/Cordova-sqlite-storage.git#storage-master"
   },
   "keywords": [
     "sqlite",


### PR DESCRIPTION
If you try to install this plugin in Cordova 7, it will fail, since there is no "master" branch, so we need to specifically define the "storage-master" branch. Also need to add "git+" to the beginning to ensure it works properly.