### PR TITLE
Fix for turkish locale

### DIFF
--- a/src/android/io/sqlc/SQLiteAndroidDatabase.java
+++ b/src/android/io/sqlc/SQLiteAndroidDatabase.java
@@ -540,7 +540,7 @@ class SQLiteAndroidDatabase
                 // (needed for SQLCipher version)
                 if (first.length() == 0) throw new RuntimeException("query not found");
 
-                return QueryType.valueOf(first.toLowerCase());
+                return QueryType.valueOf(first.toLowerCase(Locale.ENGLISH));
             } catch (IllegalArgumentException ignore) {
                 // unknown verb (NOT blank)
                 return QueryType.other;

--- a/src/android/io/sqlc/SQLiteAndroidDatabase.java
+++ b/src/android/io/sqlc/SQLiteAndroidDatabase.java
@@ -26,6 +26,7 @@ import java.lang.Number;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.Locale;
 
 import org.apache.cordova.CallbackContext;
 


### PR DESCRIPTION
While in turkish locale, transforming string with letters '**I**' and '**i**' to lowercase/uppercase cause these letters to be transofrmed into **İ** and **ı** respectively, which are not I nor i, notice the difference. This causes an exception in obtaining query type, as **ı**nsert != **i**nsert.