### PR TITLE
Cordova sqlite express EXPERIMENTAL WIP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+# cordova-sqlite-express-wip 1.0.0-pretest01
+
+New version branch WIP using builtin sqlite library on Android/iOS/macOS, no external sqlite3 dependencies
+
 ## cordova-sqlite-storage 2.1.4-fixdev01
 
 - android.database end transaction if active before closing

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## cordova-sqlite-storage 2.1.4-fixdev01
+
+- android.database end transaction if active before closing
+
 ## cordova-sqlite-storage 2.1.3
 
 ##### cordova-sqlite-legacy-core 1.0.5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Cordova/PhoneGap sqlite storage plugin
+# Cordova/PhoneGap sqlite storage express WIP
 
-Native interface to sqlite in a Cordova/PhoneGap plugin for Android, iOS, macOS, and Windows 10 (UWP), with API similar to HTML5/[Web SQL API](http://www.w3.org/TR/webdatabase/).
+Native interface to sqlite in a Cordova/PhoneGap plugin for Android, iOS, macOS, ~~and Windows 10 (UWP)~~, with API similar to HTML5/[Web SQL API](http://www.w3.org/TR/webdatabase/).
 
 License terms for Android and Windows platform versions: MIT or Apache 2.0
 
@@ -8,13 +8,18 @@ License terms for iOS/macOS platform version: MIT only
 
 ## About this version branch
 
-This is the common version branch which supports the most widely used features and serves as the basis for the other versions.
+EXPERIMENTAL "express" version with builtin sqlite3 libraries for Android/iOS/macOS, no Windows version support
 
-This version branch uses a `before_plugin_install` hook to install sqlite3 library dependencies from `cordova-sqlite-storage-dependencies` via npm.
+XXX TODO:
+- update tests for actual behavior of builtin android.database implementation
+- update this documentation
+- update description in package.json & plugin.xml
 
+<!-- XXX GONE:
 |Android Circle-CI (**full** suite)|iOS Travis-CI (partial suite)|
 |-----------------------|----------------------|
 |[![Circle CI](https://circleci.com/gh/litehelpers/Cordova-sqlite-storage.svg?style=svg)](https://circleci.com/gh/litehelpers/Cordova-sqlite-storage)|[![Build Status](https://travis-ci.org/litehelpers/Cordova-sqlite-storage.svg)](https://travis-ci.org/litehelpers/Cordova-sqlite-storage)|
+ -->
 
 <!-- FUTURE TBD critial bug notices for this version branch -->
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "cordova-sqlite-storage",
-  "version": "2.1.4-fixdev01",
+  "name": "cordova-sqlite-express-wip",
+  "version": "1.0.0-pretest01",
   "description": "Native interface to SQLite for PhoneGap/Cordova",
   "cordova": {
-    "id": "cordova-sqlite-storage",
+    "id": "cordova-sqlite-express-wip",
     "platforms": [
       "android",
       "ios",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-sqlite-storage",
-  "version": "2.1.3",
+  "version": "2.1.4-fixdev01",
   "description": "Native interface to SQLite for PhoneGap/Cordova",
   "cordova": {
     "id": "cordova-sqlite-storage",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-sqlite-storage"
-    version="2.1.3">
+    version="2.1.4-fixdev01">
 
     <name>Cordova sqlite storage plugin</name>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="cordova-sqlite-storage"
-    version="2.1.4-fixdev01">
+    id="cordova-sqlite-express-wip"
+    version="1.0.0-pretest01">
 
     <name>Cordova sqlite storage plugin</name>
 
@@ -12,9 +12,6 @@
 
     <description>Native interface to SQLite for PhoneGap/Cordova. Allows you to use more storage and provides more flexibility than the standard Web SQL database (window.openDatabase).</description>
     <author>Litehelpers/Various</author>
-
-    <!-- THANKS to AllJoyn-Cordova / cordova-plugin-alljoyn: -->
-    <hook type="before_plugin_install" src="scripts/beforePluginInstall.js" />
 
     <js-module src="www/SQLitePlugin.js" name="SQLitePlugin">
         <clobbers target="SQLitePlugin" />
@@ -31,16 +28,7 @@
 
         <source-file src="src/android/io/sqlc/SQLitePlugin.java" target-dir="src/io/sqlc"/>
         <source-file src="src/android/io/sqlc/SQLiteAndroidDatabase.java" target-dir="src/io/sqlc"/>
-        <source-file src="src/android/io/sqlc/SQLiteConnectorDatabase.java" target-dir="src/io/sqlc"/>
 
-        <!-- Android-sqlite-connector [jar]: -->
-        <source-file src="node_modules/cordova-sqlite-storage-dependencies/libs/sqlite-connector.jar" target-dir="libs"/>
-        <!-- Android-sqlite-connector native driver [native libs]: -->
-        <source-file src="node_modules/cordova-sqlite-storage-dependencies/libs/arm64-v8a/libsqlc-native-driver.so" target-dir="libs/arm64-v8a"/>
-        <source-file src="node_modules/cordova-sqlite-storage-dependencies/libs/armeabi/libsqlc-native-driver.so" target-dir="libs/armeabi"/>
-        <source-file src="node_modules/cordova-sqlite-storage-dependencies/libs/armeabi-v7a/libsqlc-native-driver.so" target-dir="libs/armeabi-v7a"/>
-        <source-file src="node_modules/cordova-sqlite-storage-dependencies/libs/x86/libsqlc-native-driver.so" target-dir="libs/x86"/>
-        <source-file src="node_modules/cordova-sqlite-storage-dependencies/libs/x86_64/libsqlc-native-driver.so" target-dir="libs/x86_64"/>
     </platform>
 
     <!-- iOS -->
@@ -59,9 +47,7 @@
         <source-file src="src/ios/PSPDFThreadSafeMutableDictionary.m"
                 compiler-flags="-w" />
 
-        <header-file src="node_modules/cordova-sqlite-storage-dependencies/sqlite3.h" />
-        <source-file src="node_modules/cordova-sqlite-storage-dependencies/sqlite3.c"
-                     compiler-flags="-w -DSQLITE_THREADSAFE=2 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DECLTYPE -DSQLITE_OMIT_DEPRECATED -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_SHARED_CACHE -DSQLITE_TEMP_STORE=2 -DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_RTREE -DSQLITE_DEFAULT_PAGE_SIZE=1024 -DSQLITE_DEFAULT_CACHE_SIZE=2000" />
+        <framework src="libsqlite3.dylib" />
     </platform>
 
     <!-- macOS (osx) -->
@@ -80,28 +66,7 @@
         <source-file src="src/ios/PSPDFThreadSafeMutableDictionary.m"
                 compiler-flags="-w" />
 
-        <header-file src="node_modules/cordova-sqlite-storage-dependencies/sqlite3.h" />
-        <source-file src="node_modules/cordova-sqlite-storage-dependencies/sqlite3.c"
-                     compiler-flags="-w -DSQLITE_THREADSAFE=2 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DECLTYPE -DSQLITE_OMIT_DEPRECATED -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_SHARED_CACHE -DSQLITE_TEMP_STORE=2 -DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_RTREE -DSQLITE_DEFAULT_PAGE_SIZE=1024" />
-    </platform>
-
-    <!-- windows -->
-    <platform name="windows">
-        <js-module src="src/windows/sqlite-proxy.js" name="SQLiteProxy">
-            <runs />
-        </js-module>
-
-        <!-- SQLite3 JS module from SQLite3-WinRT/SQLite3JS: -->
-        <js-module src="src/windows/SQLite3-Win-RT/SQLite3JS/js/SQLite3.js" name="SQLite3">
-            <runs />
-        </js-module>
-
-        <!-- Thanks to AllJoyn-Cordova / cordova-plugin-alljoyn for guidance: -->
-        <framework src="src/windows/SQLite3-Win-RT/SQLite3/SQLite3.UWP/SQLite3.UWP.vcxproj" custom="true" type="projectReference" versions="10.*" />
-        <!-- Windows 8.1 / Windows Phone 8.1 not tested, not supported in this version branch:
-        <framework src="src/windows/SQLite3-Win-RT/SQLite3/SQLite3.Windows/SQLite3.Windows.vcxproj" custom="true" type="projectReference" target="windows" versions="8.1" />
-        <framework src="src/windows/SQLite3-Win-RT/SQLite3/SQLite3.WindowsPhone/SQLite3.WindowsPhone.vcxproj" custom="true" type="projectReference" target="phone" versions="8.1" />
-         -->
+        <framework src="libsqlite3.dylib" />
     </platform>
 
 </plugin>

--- a/spec/www/spec/sqlite-version-test.js
+++ b/spec/www/spec/sqlite-version-test.js
@@ -50,7 +50,7 @@ var mytests = function() {
 
       describe(suiteName + 'basic sqlite version test(s)', function() {
 
-        it(suiteName + 'Check sqlite version (pattern ONLY for WebKit Web SQL & androidDatabaseImplementation: 2)', function(done) {
+        it(suiteName + 'Check sqlite version (pattern ONLY IN THIS VERSION BRANCH)', function(done) {
           var db = openDatabase("check-sqlite-version.db", "1.0", "Demo", DEFAULT_SIZE);
 
           expect(db).toBeDefined();
@@ -64,9 +64,10 @@ var mytests = function() {
               expect(rs.rows.length).toBe(1);
               // Check pattern (both Web SQL & plugin)
               expect(rs.rows.item(0).myResult).toMatch(/3\.[0-9]+\.[0-9]+/);
+              // XXX GONE IN THIS VERSION BRANCH:
               // Check specific [plugin only]:
-              if (!isWebSql && !(!isWindows && isAndroid && isImpl2))
-                expect(rs.rows.item(0).myResult).toBe('3.15.2');
+              //* if (!isWebSql && !(!isWindows && isAndroid && isImpl2))
+              //*   expect(rs.rows.item(0).myResult).toBe('3.15.2');
 
               // Close (plugin only) & finish:
               (isWebSql) ? done() : db.close(done, done);

--- a/src/android/io/sqlc/SQLiteAndroidDatabase.java
+++ b/src/android/io/sqlc/SQLiteAndroidDatabase.java
@@ -56,6 +56,8 @@ class SQLiteAndroidDatabase
 
     SQLiteDatabase mydb;
 
+    boolean isTransactionActive = false;
+
     /**
      * NOTE: Using default constructor, no explicit constructor.
      */
@@ -75,6 +77,10 @@ class SQLiteAndroidDatabase
      */
     void closeDatabaseNow() {
         if (mydb != null) {
+            if (isTransactionActive) {
+                mydb.endTransaction();
+                isTransactionActive = false;
+            }
             mydb.close();
             mydb = null;
         }
@@ -227,6 +233,7 @@ class SQLiteAndroidDatabase
                     needRawQuery = false;
                     try {
                         mydb.beginTransaction();
+                        isTransactionActive = true;
 
                         queryResult = new JSONObject();
                         queryResult.put("rowsAffected", 0);
@@ -242,6 +249,7 @@ class SQLiteAndroidDatabase
                     try {
                         mydb.setTransactionSuccessful();
                         mydb.endTransaction();
+                        isTransactionActive = false;
 
                         queryResult = new JSONObject();
                         queryResult.put("rowsAffected", 0);
@@ -256,6 +264,7 @@ class SQLiteAndroidDatabase
                     needRawQuery = false;
                     try {
                         mydb.endTransaction();
+                        isTransactionActive = false;
 
                         queryResult = new JSONObject();
                         queryResult.put("rowsAffected", 0);

--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -216,7 +216,7 @@ public class SQLitePlugin extends CordovaPlugin {
 
             Log.v("info", "Open sqlite db: " + dbfile.getAbsolutePath());
 
-            SQLiteAndroidDatabase mydb = old_impl ? new SQLiteAndroidDatabase() : new SQLiteConnectorDatabase();
+            SQLiteAndroidDatabase mydb = new SQLiteAndroidDatabase();
             mydb.open(dbfile);
 
             if (cbc != null) // XXX Android locking/closing BUG workaround


### PR DESCRIPTION
_NOW FIXED (see comment below):_

~~This experimental WIP change shows that the new BUG #666 workaround solution causes selfTest to fail on built-in android.database implementation (Android-sqlite-connector not used).~~

~~This is a blocking issue for #687: new major release using built-in sqlite libraries on Android/iOS/macOS~~

A _FUTURE_ TODO item is to cover this scenario in an open/close/delete test.