### PR TITLE
sql operations hangs on Android

### DIFF
--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -44,7 +44,7 @@ public class SQLitePlugin extends CordovaPlugin {
      * THANKS to @NeoLSN (Jason Yang/楊朝傑) for giving the pointer in:
      * https://github.com/litehelpers/Cordova-sqlite-storage/issues/727
      */
-    static Map<String, DBRunner> dbrmap = new ConcurrentHashMap<String, DBRunner>();
+    Map<String, DBRunner> dbrmap = new ConcurrentHashMap<String, DBRunner>();
 
     /**
      * NOTE: Using default constructor, no explicit constructor.

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -467,7 +467,20 @@
         }
       }
     };
-    cordova.exec(mycb, null, "SQLitePlugin", "backgroundExecuteSqlBatch", [
+    cordova.exec(mycb, function(message){
+/*handle transaction error caused by db-level exception, 
+      like db not open, couldn't add to queue, missing executes list etc. 
+      which failed to call the failed callback in finish function leaving the inProgress property true on Android
+      thus hanging all the operations later on.*/
+      if(typeof result === "string"){
+	          console.log(result);
+            if (tx.error && typeof tx.error === 'function') {
+                tx.error(newSQLError(result, 0));
+            }
+
+      }
+      console.log('error in running backgroundExecuteSqlBatch');
+    }, "SQLitePlugin", "backgroundExecuteSqlBatch", [
       {
         dbargs: {
           dbname: this.db.dbname

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -468,10 +468,6 @@
       }
     };
     cordova.exec(mycb, function(message){
-/*handle transaction error caused by db-level exception, 
-      like db not open, couldn't add to queue, missing executes list etc. 
-      which failed to call the failed callback in finish function leaving the inProgress property true on Android
-      thus hanging all the operations later on.*/
       if(typeof result === "string"){
 	          console.log(result);
             if (tx.error && typeof tx.error === 'function') {


### PR DESCRIPTION
1 the backgroundExecuteSqlBatch call in the SQLPlugin.js did not pass in an error callback, missing the opportunity to handle errors while leaving the inProgress property true, hanging all the operations later on

2 the static dbrmap is not working properly if there are multiple working instances of SQLPlugin. please refer to the commit comment ef71f49