### PR TITLE
use Array.isArray() function to check for arrays

### DIFF
--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -264,13 +264,13 @@
 
   SQLitePlugin.prototype.sqlBatch = function(sqlStatements, success, error) {
     var batchList, j, len1, myfn, st;
-    if (!sqlStatements || sqlStatements.constructor !== Array) {
+    if (!Array.isArray(sqlStatements)) {
       throw newSQLError('sqlBatch expects an array');
     }
     batchList = [];
     for (j = 0, len1 = sqlStatements.length; j < len1; j++) {
       st = sqlStatements[j];
-      if (st.constructor === Array) {
+      if (Array.isArray(st)) {
         if (st.length === 0) {
           throw newSQLError('sqlBatch array element of zero (0) length');
         }
@@ -360,7 +360,7 @@
     var j, len1, params, sqlStatement, t, v;
     sqlStatement = typeof sql === 'string' ? sql : sql.toString();
     params = [];
-    if (!!values && values.constructor === Array) {
+    if (Array.isArray(values)) {
       for (j = 0, len1 = values.length; j < len1; j++) {
         v = values[j];
         t = typeof v;


### PR DESCRIPTION
Currently the plugin is checking for arrays by comparing the constructor to the `Array` class.
There are cases where a JavaScript function running in another iframe or window is calling a Cordova-sqlite-storage function (like [GWT](http://www.gwtproject.org/) compiled JavaScript code).
In that case there are different array prototypes (one per window object), which nevertheless are functionally identical.
But as the check returns false, the given array is not processed any further.

The function to be used to detect an array even in these cases is [`Array.isArray()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray).
It ensures correct array detection also for iframes.

See also http://web.mit.edu/jwalden/www/isArray.html :
> Multiple globals, however, are fundamental to the browser; each window object is the global object for the scripts its page contains or references. What about arrays in different windows? The shared-mutation hazard of having arrays in two coordinating windows be instances of the same Array constructor, sharing the same Array.prototype, is enormous when either page augments Array.prototype (not to mention the security problems when one page is malicious!), **so Array and Array.prototype in each window must be different. Therefore, by the semantics of instanceof, o instanceof Array works correctly only if o is an array created by that page's original Array constructor (or, equivalently, by use of an array literal in that page).**