### PR TITLE
[MAJOR] avoid incorrect default directory on iOS/macOS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,9 @@
 
 #### cordova-sqlite-storage 5.0.0-dev
 
-TBD
+- avoid incorrect default directory on iOS/macOS - to be extra safe (see <https://github.com/xpbrew/cordova-sqlite-storage/issues/907>)
+  - ensure that default "nosync" directory *always* has resource value set for `NSURLIsExcludedFromBackupKey`
+  - add more checks for missing database directory
 
 #### cordova-sqlite-storage 4.0.0
 

--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -51,28 +51,47 @@
 
         NSString *nosync = [libs stringByAppendingPathComponent:@"LocalDatabase"];
         NSError *err;
+
+        // GENERAL NOTE: no `nosync` directory path entry to be added
+        // to appDBPaths map in case of any isses creating the
+        // required directory or setting the resource value for
+        // NSURLIsExcludedFromBackupKey
+        //
+        // This is to avoid potential for issue raised here:
+        // https://github.com/xpbrew/cordova-sqlite-storage/issues/907
+
         if ([[NSFileManager defaultManager] fileExistsAtPath: nosync])
         {
-            DLog(@"no cloud sync at path: %@", nosync);
-            [appDBPaths setObject: nosync forKey:@"nosync"];
+            DLog(@"no cloud sync directory already exists at path: %@", nosync);
         }
         else
         {
             if ([[NSFileManager defaultManager] createDirectoryAtPath: nosync withIntermediateDirectories:NO attributes: nil error:&err])
             {
-                NSURL *nosyncURL = [ NSURL fileURLWithPath: nosync];
-                if (![nosyncURL setResourceValue: [NSNumber numberWithBool: YES] forKey: NSURLIsExcludedFromBackupKey error: &err])
-                {
-                    DLog(@"IGNORED: error setting nobackup flag in LocalDatabase directory: %@", err);
-                }
-                DLog(@"no cloud sync at path: %@", nosync);
-                [appDBPaths setObject: nosync forKey:@"nosync"];
+                DLog(@"no cloud sync directory created with path: %@", nosync);
             }
             else
             {
-                // fallback:
-                DLog(@"WARNING: error adding LocalDatabase directory: %@", err);
-                [appDBPaths setObject: libs forKey:@"nosync"];
+                // STOP HERE & LOG WITH INTERNAL PLUGIN ERROR:
+                NSLog(@"INTERNAL PLUGIN ERROR: could not create no cloud sync directory at path: %@", nosync);
+                return;
+            }
+        }
+
+        {
+            {
+                // Set the resource value for NSURLIsExcludedFromBackupKey
+                NSURL *nosyncURL = [ NSURL fileURLWithPath: nosync];
+                if (![nosyncURL setResourceValue: [NSNumber numberWithBool: YES] forKey: NSURLIsExcludedFromBackupKey error: &err])
+                {
+                    // STOP HERE & LOG WITH INTERNAL PLUGIN ERROR:
+                    NSLog(@"INTERNAL PLUGIN ERROR: error setting nobackup flag in LocalDatabase directory: %@", err);
+                    return;
+                }
+
+                // now ready to add `nosync` entry to appDBPaths:
+                DLog(@"no cloud sync at path: %@", nosync);
+                [appDBPaths setObject: nosync forKey:@"nosync"];
             }
         }
     }
@@ -84,6 +103,11 @@
     }
 
     NSString *dbdir = [appDBPaths objectForKey:atkey];
+    if (dbdir == NULL) {
+        // INTERNAL PLUGIN ERROR:
+        return NULL;
+    }
+
     NSString *dbPath = [dbdir stringByAppendingPathComponent: dbFile];
     return dbPath;
 }
@@ -243,6 +267,14 @@
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"INTERNAL PLUGIN ERROR: You must specify database path"];
     } else {
         NSString *dbPath = [self getDBPath:dbFileName at:dblocation];
+
+        if (dbPath == NULL) {
+            // INTERNAL PLUGIN ERROR - NOT EXPECTED:
+            NSLog(@"INTERNAL PLUGIN ERROR (NOT EXPECTED): delete with no valid database path found");
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"INTERNAL PLUGIN ERROR: delete with no valid database path found"];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId: command.callbackId];
+            return;
+        }
 
         if ([[NSFileManager defaultManager]fileExistsAtPath:dbPath]) {
             DLog(@"delete full db path: %@", dbPath);


### PR DESCRIPTION
ensure that default "nosync" directory *always* has resource value set for `NSURLIsExcludedFromBackupKey`

(to be extra-safe)

resolves #907